### PR TITLE
add "&display=swap" for retrieved font links

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,7 +36,7 @@ async function insertFontLink() {
   // Creating the <link> markup
   const snippet = `<link href="${GoogleApi.generateUrl(
     font
-  )}" rel="stylesheet" />`;
+  )}&display=swap" rel="stylesheet" />`;
 
   // Inserting the link markup inside the editor
   insertText(snippet);
@@ -50,7 +50,7 @@ async function insertFontCssImport() {
   const font = await getGoogleFontFamilyItem();
 
   // Creating the @import url(...) snippet
-  const snippet = `@import url(${GoogleApi.generateUrl(font)});`;
+  const snippet = `@import url(${GoogleApi.generateUrl(font)}&display=swap);`;
 
   // Inserting the @import inside the editor
   insertText(snippet);


### PR DESCRIPTION
By using the display=swap option in your font link, the browser will prioritize the rendering of your content and will load the font later in the page rendering process. This can lead to a faster perceived page load time and a better user experience.